### PR TITLE
Fix a typo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ggplot1
 Version: 0.0.1.9000
 Title: Before there was ggplot2
 Description: This is the original ggplot package brought back to life mostly
-    for historial interest.
+    for historical interest.
 Author: Hadley Wickham <h.wickham@gmail.com>
 Maintainer: Hadley Wickham <h.wickham@gmail.com>
 Suggests:


### PR DESCRIPTION
I wasn't sure if it's actually a typo so I run a ngram search of [historial interest vs. historical interest](https://books.google.com/ngrams/graph?content=historial+interest%2C+historical+interest&year_start=1800&year_end=2000&corpus=15&smoothing=3&share=&direct_url=t1%3B%2Chistorial%20interest%3B%2Cc0%3B.t1%3B%2Chistorical%20interest%3B%2Cc0).
